### PR TITLE
Add nonce mutex to EVMClient for thread safety

### DIFF
--- a/packages/relayer/relayer.go
+++ b/packages/relayer/relayer.go
@@ -438,6 +438,7 @@ type EVMClient struct {
 	privateKey *ecdsa.PrivateKey
 	address    common.Address
 	logger     *zap.Logger
+	nonceMutex sync.Mutex
 }
 
 // NewEVMClient creates a new client for EVM-compatible blockchains
@@ -482,6 +483,9 @@ func (c *EVMClient) GetAddress() common.Address {
 func (c *EVMClient) SendVerifyTransaction(ctx context.Context, targetContract string, vaaBytes []byte) (string, error) {
 	c.logger.Debug("Sending verify transaction to EVM", zap.Int("vaaLength", len(vaaBytes)))
 
+	c.nonceMutex.Lock()
+	defer c.nonceMutex.Unlock()
+
 	// Contract ABI for the verify function
 	const abiJSON = `[{
         "inputs": [
@@ -515,6 +519,8 @@ func (c *EVMClient) SendVerifyTransaction(ctx context.Context, targetContract st
 	if err != nil {
 		return "", fmt.Errorf("failed to get gas price: %v", err)
 	}
+
+	c.logger.Debug("Using nonce for transaction", zap.Uint64("nonce", nonce))
 
 	// Create the transaction
 	targetAddr := common.HexToAddress(targetContract)


### PR DESCRIPTION
Introduces a sync.Mutex (nonceMutex) to EVMClient and locks it during SendVerifyTransaction to ensure thread-safe nonce usage when sending transactions. Also adds debug logging for the nonce value used.